### PR TITLE
Integrate test coverage into GitHub Actions with coveralls.io

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,6 +1,13 @@
 name: Cocoon
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -15,3 +22,34 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Select Rust nightly build
+      run: rustup default nightly
+    - name: Test with profiling
+      env:
+        CARGO_INCREMENTAL: 0
+        RUSTFLAGS: >-
+          -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code
+          -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
+        RUSTDOCFLAGS: >-
+          -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code
+          -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
+      run: cargo test --all-features
+    - name: Install grcov
+      run: |
+        curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 \
+          | tar jxf -
+    - name: Run grcov
+      run: |
+        mkdir coverage
+        ./grcov ./target/debug/ -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" \
+                --excl-line "#\[" --excl-br-line "#\[" -o ./coverage/lcov.info
+    - name: Send to Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-![Cocoon](https://github.com/fadeevab/cocoon/workflows/Cocoon/badge.svg?event=push)
+[![Cocoon](https://github.com/fadeevab/cocoon/workflows/Cocoon/badge.svg?event=push)](https://github.com/fadeevab/cocoon)
 [![crates.io](https://img.shields.io/crates/v/cocoon.svg)](https://crates.io/crates/cocoon)
 [![docs.rs](https://docs.rs/cocoon/badge.svg)](https://docs.rs/cocoon/)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fadeevab/cocoon/LICENSE)
+[![coverage](https://coveralls.io/repos/github/fadeevab/cocoon/badge.svg?branch=master)](https://coveralls.io/github/fadeevab/cocoon?branch=coveralls)
 
 # Cocoon
 


### PR DESCRIPTION
**Steps:**

1. Build with nightly toolchain and with profiling enabled.
2. Run tests with all features enabled (collecting measurement).
3. Unpack grcov from releases (`cargo install grcov` is too slow).
4. Run grcov to produce lcov.info file.
5. Send lcov.info to coveralls.io.
