### PR TITLE
Fix dev-dependencies compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ sha2 = { version = "0.8.1", default-features = false }
 zeroize = { version = "1.1.0", default-features = false }
 
 [dev-dependencies]
-borsh = "0.7"
+borsh = "0.8.1"
 
 [features]
 # Enables `std` feature by default.


### PR DESCRIPTION
Borsh 0.8.1 has been released yesterday and it resolves our compilation problem with `syn`.