### PR TITLE
update deps; aes 0.3 is dead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/cocoon"
 readme = "README.md"
 
 [dependencies]
-aes-gcm = "0.5.0"
-chacha20poly1305 = { version = "0.4.1", default-features = false, features = ["chacha20"] }
+aes-gcm = "0.9.1"
+chacha20poly1305 = { version = "0.8.1", default-features = false, features = ["chacha20"] }
 hmac = "0.7.1"
 pbkdf2 = { version = "0.3.0", default-features = false, features = ["sha2", "hmac"] }
 rand = { version = "0.7.3", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,7 @@ use header::{CocoonConfig, CocoonHeader};
 
 pub use error::Error;
 pub use header::{CocoonCipher, CocoonKdf};
+use aes_gcm::AeadInPlace;
 
 /// Grouping creation methods via generics.
 #[doc(hidden)]
@@ -753,11 +754,11 @@ impl<'a, R: CryptoRng + RngCore + Clone> Cocoon<'a, R, Creation> {
 
         let tag: [u8; 16] = match self.config.cipher() {
             CocoonCipher::Chacha20Poly1305 => {
-                let cipher = ChaCha20Poly1305::new(master_key);
+                let cipher = ChaCha20Poly1305::new(&master_key);
                 cipher.encrypt_in_place_detached(nonce, &prefix.prefix(), data)
             }
             CocoonCipher::Aes256Gcm => {
-                let cipher = Aes256Gcm::new(master_key);
+                let cipher = Aes256Gcm::new(&master_key);
                 cipher.encrypt_in_place_detached(nonce, &prefix.prefix(), data)
             }
         }
@@ -907,11 +908,11 @@ impl<'a, R: CryptoRng + RngCore + Clone, M> Cocoon<'a, R, M> {
 
         match header.config().cipher() {
             CocoonCipher::Chacha20Poly1305 => {
-                let cipher = ChaCha20Poly1305::new(master_key);
+                let cipher = ChaCha20Poly1305::new(&master_key);
                 cipher.decrypt_in_place_detached(nonce, &detached_prefix.prefix(), data, tag)
             }
             CocoonCipher::Aes256Gcm => {
-                let cipher = Aes256Gcm::new(master_key);
+                let cipher = Aes256Gcm::new(&master_key);
                 cipher.decrypt_in_place_detached(nonce, &detached_prefix.prefix(), data, tag)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,9 +263,9 @@ mod mini;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-use aes_gcm::Aes256Gcm;
+use aes_gcm::{AeadInPlace, Aes256Gcm};
 use chacha20poly1305::{
-    aead::{generic_array::GenericArray, Aead, NewAead},
+    aead::{generic_array::GenericArray, NewAead},
     ChaCha20Poly1305,
 };
 #[cfg(feature = "std")]
@@ -286,7 +286,6 @@ use header::{CocoonConfig, CocoonHeader};
 
 pub use error::Error;
 pub use header::{CocoonCipher, CocoonKdf};
-use aes_gcm::AeadInPlace;
 
 /// Grouping creation methods via generics.
 #[doc(hidden)]

--- a/src/mini.rs
+++ b/src/mini.rs
@@ -3,6 +3,9 @@ use aes_gcm::{
     Aes256Gcm,
 };
 use chacha20poly1305::ChaCha20Poly1305;
+use aes_gcm::AeadInPlace;
+use chacha20poly1305::aead::NewAead as chacha20poly1305_NewAead;
+use chacha20poly1305::aead::AeadInPlace as chacha20poly1305_AeadInPlace;
 
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 #[cfg(feature = "std")]
@@ -274,11 +277,11 @@ impl MiniCocoon {
 
         let tag: [u8; 16] = match self.config.cipher() {
             CocoonCipher::Chacha20Poly1305 => {
-                let cipher = ChaCha20Poly1305::new(key);
+                let cipher = ChaCha20Poly1305::new(&key);
                 cipher.encrypt_in_place_detached(nonce, &prefix.prefix(), data)
             }
             CocoonCipher::Aes256Gcm => {
-                let cipher = Aes256Gcm::new(key);
+                let cipher = Aes256Gcm::new(&key);
                 cipher.encrypt_in_place_detached(nonce, &prefix.prefix(), data)
             }
         }
@@ -424,11 +427,11 @@ impl MiniCocoon {
 
         match self.config.cipher() {
             CocoonCipher::Chacha20Poly1305 => {
-                let cipher = ChaCha20Poly1305::new(master_key);
+                let cipher = ChaCha20Poly1305::new(&master_key);
                 cipher.decrypt_in_place_detached(nonce, &detached_prefix.prefix(), data, tag)
             }
             CocoonCipher::Aes256Gcm => {
-                let cipher = Aes256Gcm::new(master_key);
+                let cipher = Aes256Gcm::new(&master_key);
                 cipher.decrypt_in_place_detached(nonce, &detached_prefix.prefix(), data, tag)
             }
         }

--- a/src/mini.rs
+++ b/src/mini.rs
@@ -1,11 +1,9 @@
+use aes_gcm::AeadInPlace;
 use aes_gcm::{
-    aead::{generic_array::GenericArray, Aead, NewAead},
+    aead::{generic_array::GenericArray, NewAead},
     Aes256Gcm,
 };
 use chacha20poly1305::ChaCha20Poly1305;
-use aes_gcm::AeadInPlace;
-use chacha20poly1305::aead::NewAead as chacha20poly1305_NewAead;
-use chacha20poly1305::aead::AeadInPlace as chacha20poly1305_AeadInPlace;
 
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 #[cfg(feature = "std")]


### PR DESCRIPTION
Cool library! I'm going to use this to store secret keys for a crypto wallet. 

When I run `cargo build` on the current master I get:
```
error: failed to select a version for the requirement `aes = "^0.3"`
candidate versions found which didn't match: 0.7.4, 0.7.3, 0.7.2, ...
location searched: crates.io index
required by package `aes-gcm v0.5.0`
```
Apparently aes 0.3 has been yanked.