### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocoon"
-version = "0.3.0"
+version = "0.3.1-pre"
 description = "A simple protected container with strong encryption and format validation."
 authors = ["Alexander Fadeev <fadeevab.com@gmail.com>"]
 edition = "2018"
@@ -13,16 +13,16 @@ documentation = "https://docs.rs/cocoon"
 readme = "README.md"
 
 [dependencies]
-aes-gcm = "0.9"
-chacha20poly1305 = { version = "0.9", default-features = false }
-hmac = "0.11"
-pbkdf2 = { version = "0.9", default-features = false, features = ["sha2", "hmac"] }
-rand = { version = "0.8", default-features = false, features = ["std_rng"] }
-sha2 = { version = "0.9", default-features = false }
-zeroize = { version = "1", default-features = false }
+aes-gcm = "0.9.4"
+chacha20poly1305 = { version = "0.10.0-pre", default-features = false }
+hmac = "0.12.1"
+pbkdf2 = { version = "0.11.0", default-features = false, features = ["sha2", "hmac"] }
+rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
+sha2 = { version = "0.10.2", default-features = false }
+zeroize = { version = "1.5.5", default-features = false }
 
 [dev-dependencies]
-borsh = "0.9"
+borsh = "0.9.3"
 
 [features]
 # Enables `std` feature by default.


### PR DESCRIPTION
I really love this project and I want to use it but it cause some problems with dependencies because of `chacha20poly1305` crate that needs an old version of `zeroize`.
The developer published a pre-release (0.10.0-pre) so I'll appreciate if you can publish a -pre release too with some upgraded dependencies.

Thanks