### PR TITLE
Make `no_std` work with `aes-gcm` no default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/cocoon"
 readme = "README.md"
 
 [dependencies]
-aes-gcm = "0.10"
+aes-gcm = { version = "0.10", default-features = false, features = ["aes"] }
 chacha20poly1305 = { version = "0.10", default-features = false }
 hmac = "0.11"
 pbkdf2 = { version = "0.9", default-features = false, features = ["sha2", "hmac"] }

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -1,6 +1,6 @@
 pub const KEY_SIZE: usize = 32;
 pub const SALT_MIN_SIZE: usize = 16;
-pub const SALT_MAX_SIZE: usize = 64;
+pub const SALT_MAX_SIZE: usize = 128;
 
 /// A 256-bit key derived from a password using PBKDF2 (HMAC-SHA256) with guaranteed zeroization.
 pub mod pbkdf2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -999,6 +999,25 @@ mod test {
     }
 
     #[test]
+    fn cocoon_decrypt_aes() {
+        let detached_prefix = [
+            127, 192, 10, 1, 2, 1, 2, 0, 155, 244, 154, 106, 7, 85, 249, 83, 129, 31, 206, 18, 95,
+            38, 131, 213, 4, 41, 195, 187, 73, 224, 116, 20, 126, 0, 137, 165, 0, 0, 0, 0, 0, 0, 0,
+            14, 103, 127, 175, 154, 15, 80, 248, 145, 128, 241, 138, 15, 154, 128, 201, 157,
+        ];
+        let mut data = [
+            88, 183, 11, 7, 192, 224, 203, 107, 144, 162, 48, 78, 61, 223,
+        ];
+        let cocoon = Cocoon::parse_only(b"password");
+
+        cocoon
+            .decrypt(&mut data, &detached_prefix)
+            .expect("Decrypted data");
+
+        assert_eq!(b"my secret data", &data);
+    }
+
+    #[test]
     fn cocoon_wrap() {
         let cocoon = Cocoon::from_seed(b"password", [0; 32]);
         let wrapped = cocoon.wrap(b"data").expect("Wrapped container");


### PR DESCRIPTION
Problem:  `getrandom` with `std` was linked
Cause: `aes-gcm` with default features
Measure: `aes-gcm` default-features = false

Also, `concat` doesn't work in `no_std` environment, fixed with manual slice concatting (introduces the max salt length :( ).

Fixing #19 