### PR TITLE
Implement `std::error::Error` for `cocoon::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ hmac = "0.11"
 pbkdf2 = {version = "0.9", default-features = false, features = ["sha2", "hmac"]}
 rand = {version = "0.8", default-features = false, features = ["std_rng"]}
 sha2 = {version = "0.9", default-features = false}
+thiserror = {version = "1.0.61", optional = true}
 zeroize = {version = "1", default-features = false}
 
 [dev-dependencies]
@@ -31,7 +32,7 @@ default = ["std"]
 
 # Enables all features, including support of simplified Cocoon API, using `rand::thread_rng`,
 # and API related to `std::io`: wrap to writer, unwrap from reader.
-std = ["alloc", "rand/std"]
+std = ["alloc", "rand/std", "dep:thiserror"]
 
 # Enables `Vec` container. Can be used without `std` crate (in "no std" build).
 alloc = ["chacha20poly1305/alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default = ["std"]
 
 # Enables all features, including support of simplified Cocoon API, using `rand::thread_rng`,
 # and API related to `std::io`: wrap to writer, unwrap from reader.
-std = ["alloc", "rand/std", "thiserror"]
+std = ["alloc", "rand/std"]
 
 # Enables `Vec` container. Can be used without `std` crate (in "no std" build).
 alloc = ["chacha20poly1305/alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ default = ["std"]
 
 # Enables all features, including support of simplified Cocoon API, using `rand::thread_rng`,
 # and API related to `std::io`: wrap to writer, unwrap from reader.
-std = ["alloc", "rand/std", "dep:thiserror"]
+std = ["alloc", "rand/std", "thiserror"]
+thiserror = ["std"]
 
 # Enables `Vec` container. Can be used without `std` crate (in "no std" build).
 alloc = ["chacha20poly1305/alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ default = ["std"]
 # Enables all features, including support of simplified Cocoon API, using `rand::thread_rng`,
 # and API related to `std::io`: wrap to writer, unwrap from reader.
 std = ["alloc", "rand/std", "thiserror"]
-thiserror = ["std"]
 
 # Enables `Vec` container. Can be used without `std` crate (in "no std" build).
 alloc = ["chacha20poly1305/alloc"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,20 +1,26 @@
 /// Error variants produced by the Cocoon API.
 #[derive(Debug)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum Error {
     /// I/o error during read/write operation (`Cocoon::dump`, `Cocoon::parse`).
     #[cfg(feature = "std")]
+    #[error("Input/output error")]
     Io(std::io::Error),
     /// Format is not recognized. Probably corrupted.
+    #[cfg_attr(feature = "std", error("Unrecognized format"))]
     UnrecognizedFormat,
     /// Cryptographic error. There could be a few reasons:
     /// 1. Integrity is compromised.
     /// 2. Password is invalid.
+    #[cfg_attr(feature = "std", error("Cryptographic error: bad integrity/password?"))]
     Cryptography,
     /// Container is too large to get processed on the current architecture.
     /// E.g. it's not possible to process a container larger than 4 GB on 32-bit architecture.
+    #[cfg_attr(feature = "std", error("Container size exceeds architectural limit"))]
     TooLarge,
     /// Buffer is too short and barely holds all data to decrypt, inconsistent length
     /// encoded to the header.
+    #[cfg_attr(feature = "std", error("Insufficient buffer size for decyrpted data"))]
     TooShort,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     /// Cryptographic error. There could be a few reasons:
     /// 1. Integrity is compromised.
     /// 2. Password is invalid.
-    #[cfg_attr(feature = "std", error("Cryptographic error: bad integrity/password?"))]
+    #[cfg_attr(feature = "std", error("Cryptographic error: bad integrity/password"))]
     Cryptography,
     /// Container is too large to get processed on the current architecture.
     /// E.g. it's not possible to process a container larger than 4 GB on 32-bit architecture.

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     TooLarge,
     /// Buffer is too short and barely holds all data to decrypt, inconsistent length
     /// encoded to the header.
-    #[cfg_attr(feature = "std", error("Insufficient buffer size for decyrpted data"))]
+    #[cfg_attr(feature = "std", error("Insufficient buffer size for decrypted data"))]
     TooShort,
 }
 


### PR DESCRIPTION
This adds the `std::error::Error` trait implementation to `cocoon::Error` using the `thiserror` crate.
Note that this is only limited to the presence of feature "std".