### PR TITLE
CI: `grcov` -> `llvm-cov` (fix test coverage issues).

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate code coverage
-      run: cargo llvm-cov --tests --all-features --lcov --output-path ./coverage/lcov.info
+      run: mkdir coverage && cargo llvm-cov --tests --all-features --lcov --output-path ./coverage/lcov.info
     - name: Send to Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -31,30 +31,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Select Rust nightly build
-      run: rustup default nightly
-    - name: Test with profiling
-      env:
-        CARGO_INCREMENTAL: 0
-        RUSTFLAGS: >-
-          -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code
-          -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
-        RUSTDOCFLAGS: >-
-          -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code
-          -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
-      run: cargo test --all-features
-    - name: Install grcov
-      run: |
-        curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 \
-          | tar jxf -
-    - name: Run grcov
-      run: |
-        mkdir coverage
-        ./grcov ./target/debug/ -s . -t lcov --llvm --branch --ignore-not-existing \
-                --ignore "/*" --ignore "src/error.rs" \
-                --excl-line '#\[|=> panic!|unreachable!|Io\(std::io::Error\)|//!|///|^[ }]*$' \
-                --excl-br-line '#\[|=> panic!|unreachable!|assert_..!|//!|///' -o ./coverage/lcov.info
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      run: rustup update stable
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Generate code coverage
+      run: cargo llvm-cov --tests --all-features --lcov --output-path ./coverage/lcov.info
     - name: Send to Coveralls
       uses: coverallsapp/github-action@master
       with:


### PR DESCRIPTION
Problem: I got a simple PR with `derive(Clone)` and coverage dropped from 86% to ~20%.
Cause: `grcov` branch coverage is unstable. Last issue: it found ~3600 branches instead of ~360 ones.
Measure: Using `llvm-cov` instead.